### PR TITLE
Custom Player: support chat-downloader output without "time_in_seconds" values

### DIFF
--- a/modules/CustomPlayerPage.tsx
+++ b/modules/CustomPlayerPage.tsx
@@ -15,6 +15,7 @@ const CustomPlayerPage = () => {
   const [urlVideo, setUrlVideo] = React.useState('');
   const [urlChat, setUrlChat] = React.useState('');
   const [urlYtt, setUrlYtt] = React.useState('');
+  const [urlInfo, setUrlInfo] = React.useState('');
   const [showPlayer, setShowPlayer] = React.useState(false);
 
   const handleFile = (
@@ -83,6 +84,7 @@ const CustomPlayerPage = () => {
               ) : (
                 <ChatReplayPanel
                   src={urlChat}
+                  info={urlInfo}
                   currentTimeSeconds={playbackProgress}
                   onChatToggle={setIsChatVisible}
                 />
@@ -168,6 +170,20 @@ const CustomPlayerPage = () => {
                   accept=".srv3"
                   className="hidden"
                   onChange={(e) => handleFile(e, setUrlYtt)}
+                />
+              </label>
+              <label
+                className={[buttonStyle, 'relative cursor-pointer'].join(' ')}
+              >
+                <span>Select info json</span>
+                <span className="ml-auto">
+                  {urlInfo ? <IconCheck width="1em" height="1em" /> : null}
+                </span>
+                <input
+                  type="file"
+                  accept=".json"
+                  className="hidden"
+                  onChange={(e) => handleFile(e, setUrlInfo)}
                 />
               </label>
 

--- a/modules/CustomPlayerPage.tsx
+++ b/modules/CustomPlayerPage.tsx
@@ -137,6 +137,7 @@ const CustomPlayerPage = () => {
                 </span>
                 <input
                   type="file"
+                  accept="video/*"
                   className="hidden"
                   onChange={(e) => handleFile(e, setUrlVideo)}
                 />
@@ -150,6 +151,7 @@ const CustomPlayerPage = () => {
                 </span>
                 <input
                   type="file"
+                  accept=".json"
                   className="hidden"
                   onChange={(e) => handleFile(e, setUrlChat)}
                 />
@@ -163,6 +165,7 @@ const CustomPlayerPage = () => {
                 </span>
                 <input
                   type="file"
+                  accept=".srv3"
                   className="hidden"
                   onChange={(e) => handleFile(e, setUrlYtt)}
                 />

--- a/modules/shared/ChatReplay/ChatReplayPanel.tsx
+++ b/modules/shared/ChatReplay/ChatReplayPanel.tsx
@@ -8,6 +8,7 @@ import { parseChatReplay } from './parser';
 
 export type ChatReplayPanelProps = {
   src: string;
+  info: string;
   currentTimeSeconds: number;
   onChatToggle?: (isVisible: boolean) => any;
 };
@@ -35,7 +36,11 @@ const ChatReplayPanel = (props: ChatReplayPanelProps) => {
         transformResponse: (res) => res,
       });
 
-      setReplayData(parseChatReplay(data.data));
+      const info = await axios.get(props.info, {
+        transformResponse: (res) => res,
+      });
+
+      setReplayData(parseChatReplay(data.data, info.data));
       setIsChatVisible(true);
     } catch (ex) {
       console.log('[chat] error parsing chat:', ex);

--- a/modules/shared/ChatReplay/ChatReplayPanel.tsx
+++ b/modules/shared/ChatReplay/ChatReplayPanel.tsx
@@ -8,7 +8,7 @@ import { parseChatReplay } from './parser';
 
 export type ChatReplayPanelProps = {
   src: string;
-  info: string;
+  info?: string;
   currentTimeSeconds: number;
   onChatToggle?: (isVisible: boolean) => any;
 };
@@ -36,9 +36,9 @@ const ChatReplayPanel = (props: ChatReplayPanelProps) => {
         transformResponse: (res) => res,
       });
 
-      const info = await axios.get(props.info, {
+      const info: any = props.info ? await axios.get(props.info, {
         transformResponse: (res) => res,
-      });
+      }) : {};
 
       setReplayData(parseChatReplay(data.data, info.data));
       setIsChatVisible(true);

--- a/modules/shared/ChatReplay/parser/default.ts
+++ b/modules/shared/ChatReplay/parser/default.ts
@@ -8,7 +8,7 @@ export default class DefaultChatParser implements ChatReplayParser {
 
   constructor(chatData: string, videoInfo: string) {
     this.chatData = chatData.trim();
-    this.videoInfo = videoInfo.trim();
+    this.videoInfo = videoInfo ? videoInfo.trim() : '';
   }
 
   canParse(): boolean {
@@ -22,22 +22,21 @@ export default class DefaultChatParser implements ChatReplayParser {
   }
 
   parse(): ChatMessage[] {
-    this.chatData = JSON.parse(this.chatData);
+    const actions = JSON.parse(this.chatData);
 
     // Handle live_chat.json without time_in_seconds values
     if (
-      this.chatData.length > 0 &&
-      !('time_in_seconds' in this.chatData[0])
+      actions.length > 0 &&
+      !('time_in_seconds' in actions[0])
     ) {
-      this.videoInfo = JSON.parse(this.videoInfo);
       // Read stream start time from info.json (as seconds)
-      const startTime = Number(this.videoInfo.release_timestamp);
+      const startTime = Number(JSON.parse(this.videoInfo).release_timestamp);
       // Action times are microseconds
-      this.chatData.forEach((action) =>
+      actions.forEach((action) =>
         action.time_in_seconds = (action.timestamp / 1000000) - startTime
       );
     }
 
-    return this.chatData.sort((a, b) => a.time_in_seconds - b.time_in_seconds) as ChatMessage[];
+    return actions.sort((a, b) => a.time_in_seconds - b.time_in_seconds) as ChatMessage[];
   }
 }

--- a/modules/shared/ChatReplay/parser/default.ts
+++ b/modules/shared/ChatReplay/parser/default.ts
@@ -4,18 +4,40 @@ import { ChatMessage } from '../../database.d';
 export default class DefaultChatParser implements ChatReplayParser {
   name: 'DefaultChatParser';
   chatData: string = '';
+  videoInfo: string = '';
 
-  constructor(chatData: string) {
+  constructor(chatData: string, videoInfo: string) {
     this.chatData = chatData.trim();
+    this.videoInfo = videoInfo.trim();
   }
 
   canParse(): boolean {
-    return this.chatData.startsWith('[') && this.chatData.endsWith(']');
+    return (
+      this.chatData.startsWith('[') &&
+      this.chatData.endsWith(']') && (
+        this.chatData.includes('time_in_seconds') ||
+        this.videoInfo.includes('release_timestamp')
+      )
+    );
   }
 
   parse(): ChatMessage[] {
-    return (JSON.parse(this.chatData) as ChatMessage[]).sort(
-      (a, b) => a.time_in_seconds - b.time_in_seconds
-    );
+    this.chatData = JSON.parse(this.chatData);
+
+    // Handle live_chat.json without time_in_seconds values
+    if (
+      this.chatData.length > 0 &&
+      !('time_in_seconds' in this.chatData[0])
+    ) {
+      this.videoInfo = JSON.parse(this.videoInfo);
+      // Read stream start time from info.json (as seconds)
+      const startTime = Number(this.videoInfo.release_timestamp);
+      // Action times are microseconds
+      this.chatData.forEach((action) =>
+        action.time_in_seconds = (action.timestamp / 1000000) - startTime
+      );
+    }
+
+    return this.chatData.sort((a, b) => a.time_in_seconds - b.time_in_seconds) as ChatMessage[];
   }
 }

--- a/modules/shared/ChatReplay/parser/index.ts
+++ b/modules/shared/ChatReplay/parser/index.ts
@@ -5,7 +5,7 @@ import YtDlpChatParser from './yt-dlp';
 export abstract class ChatReplayParser {
   name: string = '';
 
-  constructor(chatData: string) {
+  constructor(chatData: string, videoInfo: string) {
     if (this.constructor === ChatReplayParser)
       throw new Error("Abstract classes can't be instantiated.");
   }
@@ -19,10 +19,10 @@ export abstract class ChatReplayParser {
   }
 }
 
-export const parseChatReplay = (input: string) => {
+export const parseChatReplay = (input: string, info: string) => {
   console.log('[chat] parsing chat data');
   const parser = [DefaultChatParser, YtDlpChatParser]
-    .map((Parser) => new Parser(input))
+    .map((Parser) => new Parser(input, info))
     .find((parser) => parser.canParse());
   if (!parser) throw new Error('No suitable chat parser found');
   console.log('[chat] using', parser.name);


### PR DESCRIPTION
If you try to load `live_chat.json` from a certain drawer with a can of socks, the Custom Player page will hang in an infinite loop since there are no `time_in_seconds` values in the live chat array (only timestamps).

This happens because [xenova/chat-downloader](https://github.com/xenova/chat-downloader) doesn't save them for live videos: [youtube.py#L719](https://github.com/xenova/chat-downloader/blob/master/chat_downloader/sites/youtube.py#L719)

A solution is to also load `info.json` (generated by yt-dlp), get `release_timestamp` from there and calculate the offset.
Tested and working for me this way. Chat messages are in sync with the video.

I also added file extension filters to make picking files easier.