### PR TITLE
Chat Panel: add buttons to hide header/footer and make scrolling instant, UI fixes

### DIFF
--- a/modules/CustomPlayerPage.tsx
+++ b/modules/CustomPlayerPage.tsx
@@ -7,9 +7,10 @@ import VideoPlayer2 from './shared/VideoPlayer/VideoPlayer2';
 import { buttonStyle } from './shared/VideoActionButtons';
 import { IconCheck } from './shared/icons';
 import { SITE_NAME } from './shared/config';
+import { useLocalStorage } from './shared/hooks/useLocalStorage';
 
 const CustomPlayerPage = () => {
-  const [isChatVisible, setIsChatVisible] = React.useState(false);
+  const [isChatVisible, setIsChatVisible] = useLocalStorage('chat:visible', true);
   const { innerWidth, innerHeight } = useWindowSize();
   const [playbackProgress, setPlaybackProgress] = React.useState(0);
   const [urlVideo, setUrlVideo] = React.useState('');
@@ -40,7 +41,7 @@ const CustomPlayerPage = () => {
       {showPlayer ? (
         <div>
           <div
-            className={['flex lg:flex-row flex-col lg:h-auto'].join(' ')}
+            className="flex lg:flex-row flex-col lg:h-auto"
             style={{
               height: isChatVisible && innerWidth < 640 ? innerHeight : 'auto',
             }}
@@ -86,7 +87,6 @@ const CustomPlayerPage = () => {
                   src={urlChat}
                   info={urlInfo}
                   currentTimeSeconds={playbackProgress}
-                  onChatToggle={setIsChatVisible}
                 />
               )}
             </div>

--- a/modules/CustomPlayerPage.tsx
+++ b/modules/CustomPlayerPage.tsx
@@ -7,10 +7,10 @@ import VideoPlayer2 from './shared/VideoPlayer/VideoPlayer2';
 import { buttonStyle } from './shared/VideoActionButtons';
 import { IconCheck } from './shared/icons';
 import { SITE_NAME } from './shared/config';
-import { useLocalStorage } from './shared/hooks/useLocalStorage';
+import useLocalStorageState from 'use-local-storage-state';
 
 const CustomPlayerPage = () => {
-  const [isChatVisible, setIsChatVisible] = useLocalStorage('chat:visible', true);
+  const [isChatVisible, setIsChatVisible] = useLocalStorageState('chat:visible', { defaultValue: true });
   const { innerWidth, innerHeight } = useWindowSize();
   const [playbackProgress, setPlaybackProgress] = React.useState(0);
   const [urlVideo, setUrlVideo] = React.useState('');

--- a/modules/CustomPlayerPage.tsx
+++ b/modules/CustomPlayerPage.tsx
@@ -43,7 +43,7 @@ const CustomPlayerPage = () => {
           <div
             className="flex lg:flex-row flex-col lg:h-auto"
             style={{
-              height: isChatVisible && innerWidth < 640 ? innerHeight : 'auto',
+              height: isChatVisible && innerWidth < 1024 ? innerHeight : 'auto',
             }}
           >
             <div className="w-full lg:w-3/4">

--- a/modules/CustomPlayerPage.tsx
+++ b/modules/CustomPlayerPage.tsx
@@ -11,6 +11,7 @@ import useLocalStorageState from 'use-local-storage-state';
 
 const CustomPlayerPage = () => {
   const [isChatVisible, setIsChatVisible] = useLocalStorageState('chat:visible', { defaultValue: true });
+  const [isHeaderVisible, setIsHeaderVisible] = useLocalStorageState('header:visible', { defaultValue: true });
   const { innerWidth, innerHeight } = useWindowSize();
   const [playbackProgress, setPlaybackProgress] = React.useState(0);
   const [urlVideo, setUrlVideo] = React.useState('');
@@ -91,13 +92,15 @@ const CustomPlayerPage = () => {
               )}
             </div>
           </div>
-          <button
-            type="button"
-            className={[buttonStyle, 'mt-4'].join(' ')}
-            onClick={() => setShowPlayer(false)}
-          >
-            Go back
-          </button>
+          {isHeaderVisible && (
+            <button
+              type="button"
+              className={[buttonStyle, 'mt-4'].join(' ')}
+              onClick={() => setShowPlayer(false)}
+            >
+              Go back
+            </button>
+          )}
         </div>
       ) : (
         <div>

--- a/modules/WatchPage.tsx
+++ b/modules/WatchPage.tsx
@@ -76,7 +76,7 @@ const WatchPage = (props: WatchPageProps) => {
       <div
         className="flex lg:flex-row flex-col lg:h-auto"
         style={{
-          height: isChatVisible && innerWidth < 640 ? innerHeight : 'auto',
+          height: isChatVisible && innerWidth < 1024 ? innerHeight : 'auto',
         }}
       >
         <div className="w-full lg:w-3/4">

--- a/modules/WatchPage.tsx
+++ b/modules/WatchPage.tsx
@@ -16,7 +16,7 @@ import ExpandableContainer from './ExpandableContainer';
 import CommentSection from './CommentSection';
 import { NextImage } from './shared/NextImage';
 import { parseTimestamp } from './shared/util';
-import { useLocalStorage } from './shared/hooks/useLocalStorage';
+import useLocalStorageState from 'use-local-storage-state';
 
 const format = (n: number) => Intl.NumberFormat('en-US').format(n);
 
@@ -38,7 +38,7 @@ const WatchPage = (props: WatchPageProps) => {
 
   const { videoInfo, hasChat, relatedVideos } = props;
 
-  const [isChatVisible, setIsChatVisible] = useLocalStorage('chat:visible', true);
+  const [isChatVisible, setIsChatVisible] = useLocalStorageState('chat:visible', { defaultValue: true });
   const refMobileScrollTarget = React.useRef<HTMLDivElement>(null);
   const { innerWidth, innerHeight } = useWindowSize();
 

--- a/modules/WatchPage.tsx
+++ b/modules/WatchPage.tsx
@@ -16,6 +16,7 @@ import ExpandableContainer from './ExpandableContainer';
 import CommentSection from './CommentSection';
 import { NextImage } from './shared/NextImage';
 import { parseTimestamp } from './shared/util';
+import { useLocalStorage } from './shared/hooks/useLocalStorage';
 
 const format = (n: number) => Intl.NumberFormat('en-US').format(n);
 
@@ -37,7 +38,7 @@ const WatchPage = (props: WatchPageProps) => {
 
   const { videoInfo, hasChat, relatedVideos } = props;
 
-  const [isChatVisible, setIsChatVisible] = React.useState(false);
+  const [isChatVisible, setIsChatVisible] = useLocalStorage('chat:visible', true);
   const refMobileScrollTarget = React.useRef<HTMLDivElement>(null);
   const { innerWidth, innerHeight } = useWindowSize();
 
@@ -73,7 +74,7 @@ const WatchPage = (props: WatchPageProps) => {
     <PageBase>
       <VideoPlayerHead videoInfo={videoInfo} />
       <div
-        className={['flex lg:flex-row flex-col lg:h-auto'].join(' ')}
+        className="flex lg:flex-row flex-col lg:h-auto"
         style={{
           height: isChatVisible && innerWidth < 640 ? innerHeight : 'auto',
         }}
@@ -145,7 +146,6 @@ const WatchPage = (props: WatchPageProps) => {
             <ChatReplayPanel
               src={urlChat}
               currentTimeSeconds={playbackProgress}
-              onChatToggle={setIsChatVisible}
             />
           )}
         </div>

--- a/modules/shared/ChatReplay/ChatReplayPanel.tsx
+++ b/modules/shared/ChatReplay/ChatReplayPanel.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import axios from 'axios';
 import { ChatMessage } from '../database.d';
 import ChatReplay from './ChatReplay';
-import { IconChevronDown, IconFilter } from '../icons';
+import { IconChevronDown, IconFilter, IconBars } from '../icons';
 import { useDebounce } from '../hooks/useDebounce';
 import { parseChatReplay } from './parser';
-import { useLocalStorage } from '../hooks/useLocalStorage';
+import useLocalStorageState from 'use-local-storage-state';
 
 export type ChatReplayPanelProps = {
   src: string;
@@ -20,7 +20,8 @@ const ChatReplayPanel = (props: ChatReplayPanelProps) => {
   const [downloadProgress, setDownloadProgress] = React.useState(-1);
   const [isFilterVisible, setIsFilterVisible] = React.useState(false);
   const [chatFilter, setChatFilter] = React.useState('');
-  const [isChatVisible, setIsChatVisible] = useLocalStorage('chat:visible', true);
+  const [isChatVisible, setIsChatVisible] = useLocalStorageState('chat:visible', { defaultValue: true });
+  const [isHeaderVisible, setIsHeaderVisible] = useLocalStorageState('header:visible', { defaultValue: true });
   const [isErrored, setIsErrored] = React.useState(false);
   const refChatScrollDiv = React.useRef<HTMLDivElement>(null);
 
@@ -104,6 +105,19 @@ const ChatReplayPanel = (props: ChatReplayPanelProps) => {
         <div className="flex">
           <div className="flex-1 flex items-center px-4">Chat replay</div>
           <div>
+            <button
+              type="button"
+              title={isHeaderVisible ? 'Hide header' : 'Show header'}
+              onClick={() => setIsHeaderVisible((now) => !now)}
+              className="px-4 py-2"
+              style={{
+                transitionDuration: '0.3s',
+                transitionProperty: 'transform',
+                transform: isHeaderVisible ? 'none' : 'rotate(90deg)'
+              }}
+            >
+              <IconBars width="1em" height="1em" />
+            </button>
             <button
               type="button"
               title="Filter text"

--- a/modules/shared/ChatReplay/ChatReplayPanel.tsx
+++ b/modules/shared/ChatReplay/ChatReplayPanel.tsx
@@ -5,12 +5,12 @@ import ChatReplay from './ChatReplay';
 import { IconChevronDown, IconFilter } from '../icons';
 import { useDebounce } from '../hooks/useDebounce';
 import { parseChatReplay } from './parser';
+import { useLocalStorage } from '../hooks/useLocalStorage';
 
 export type ChatReplayPanelProps = {
   src: string;
   info?: string;
   currentTimeSeconds: number;
-  onChatToggle?: (isVisible: boolean) => any;
 };
 
 const ChatReplayPanel = (props: ChatReplayPanelProps) => {
@@ -20,7 +20,7 @@ const ChatReplayPanel = (props: ChatReplayPanelProps) => {
   const [downloadProgress, setDownloadProgress] = React.useState(-1);
   const [isFilterVisible, setIsFilterVisible] = React.useState(false);
   const [chatFilter, setChatFilter] = React.useState('');
-  const [isChatVisible, setIsChatVisible] = React.useState(false);
+  const [isChatVisible, setIsChatVisible] = useLocalStorage('chat:visible', true);
   const [isErrored, setIsErrored] = React.useState(false);
   const refChatScrollDiv = React.useRef<HTMLDivElement>(null);
 
@@ -41,7 +41,6 @@ const ChatReplayPanel = (props: ChatReplayPanelProps) => {
       }) : {};
 
       setReplayData(parseChatReplay(data.data, info.data));
-      setIsChatVisible(true);
     } catch (ex) {
       console.log('[chat] error parsing chat:', ex);
       setIsErrored(true);
@@ -76,10 +75,6 @@ const ChatReplayPanel = (props: ChatReplayPanelProps) => {
       });
   }, [props.currentTimeSeconds]);
 
-  React.useEffect(() => {
-    props.onChatToggle?.(isChatVisible);
-  }, [isChatVisible]);
-
   if (replayData === null)
     return (
       <div
@@ -111,6 +106,7 @@ const ChatReplayPanel = (props: ChatReplayPanelProps) => {
           <div>
             <button
               type="button"
+              title="Filter text"
               onClick={() => setIsFilterVisible((now) => !now)}
               className="px-4 py-2"
             >
@@ -118,13 +114,18 @@ const ChatReplayPanel = (props: ChatReplayPanelProps) => {
             </button>
             <button
               type="button"
+              title={isChatVisible ? 'Collapse chat' : 'Expand chat'}
               onClick={() => setIsChatVisible((now) => !now)}
               className="text-lg px-4 py-2"
             >
               <IconChevronDown
                 width="1em"
                 height="1em"
-                style={{ transform: isChatVisible ? 'rotate(180deg)' : '' }}
+                style={{
+                  transitionDuration: '0.3s',
+                  transitionProperty: 'transform',
+                  transform: isChatVisible ? 'scaleY(-1)' : 'none'
+                }}
               />
             </button>
           </div>

--- a/modules/shared/ChatReplay/ChatReplayPanel.tsx
+++ b/modules/shared/ChatReplay/ChatReplayPanel.tsx
@@ -108,7 +108,7 @@ const ChatReplayPanel = (props: ChatReplayPanelProps) => {
           <div>
             <button
               type="button"
-              title={isHeaderVisible ? 'Hide header' : 'Show header'}
+              title={isHeaderVisible ? 'Hide header and footer' : 'Show header and footer'}
               onClick={() => setIsHeaderVisible((now) => !now)}
               className="px-2 py-2"
               style={{

--- a/modules/shared/ChatReplay/ChatReplayPanel.tsx
+++ b/modules/shared/ChatReplay/ChatReplayPanel.tsx
@@ -182,7 +182,7 @@ const ChatReplayPanel = (props: ChatReplayPanelProps) => {
           <div
             className={[
               'px-2 border border-gray-800 rounded',
-              'overflow-y-scroll absolute inset-0',
+              'overflow-hidden hover:overflow-y-scroll absolute inset-0',
               'transition-all duration-200',
             ].join(' ')}
             style={{

--- a/modules/shared/ChatReplay/ChatReplayPanel.tsx
+++ b/modules/shared/ChatReplay/ChatReplayPanel.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import axios from 'axios';
 import { ChatMessage } from '../database.d';
 import ChatReplay from './ChatReplay';
-import { IconChevronDown, IconFilter, IconBars } from '../icons';
+import { IconChevronDown, IconFilter, IconBars, IconTachometerAlt } from '../icons';
 import { useDebounce } from '../hooks/useDebounce';
 import { parseChatReplay } from './parser';
 import useLocalStorageState from 'use-local-storage-state';
@@ -21,6 +21,7 @@ const ChatReplayPanel = (props: ChatReplayPanelProps) => {
   const [isFilterVisible, setIsFilterVisible] = React.useState(false);
   const [chatFilter, setChatFilter] = React.useState('');
   const [isChatVisible, setIsChatVisible] = useLocalStorageState('chat:visible', { defaultValue: true });
+  const [isChatSmooth, setIsChatSmooth] = useLocalStorageState('chat:smooth', { defaultValue: true });
   const [isHeaderVisible, setIsHeaderVisible] = useLocalStorageState('header:visible', { defaultValue: true });
   const [isErrored, setIsErrored] = React.useState(false);
   const refChatScrollDiv = React.useRef<HTMLDivElement>(null);
@@ -72,7 +73,7 @@ const ChatReplayPanel = (props: ChatReplayPanelProps) => {
     if (refChatScrollDiv.current)
       refChatScrollDiv.current.scrollTo({
         top: refChatScrollDiv.current.scrollHeight,
-        behavior: 'smooth',
+        behavior: isChatSmooth ? 'smooth' : 'instant',
       });
   }, [props.currentTimeSeconds]);
 
@@ -103,34 +104,48 @@ const ChatReplayPanel = (props: ChatReplayPanelProps) => {
     <div className="h-full flex flex-col">
       <div className="flex flex-col text-white bg-gray-900">
         <div className="flex">
-          <div className="flex-1 flex items-center px-4">Chat replay</div>
+          <div className="flex-1 flex items-center px-2">Chat replay</div>
           <div>
             <button
               type="button"
               title={isHeaderVisible ? 'Hide header' : 'Show header'}
               onClick={() => setIsHeaderVisible((now) => !now)}
-              className="px-4 py-2"
+              className="px-2 py-2"
               style={{
                 transitionDuration: '0.3s',
                 transitionProperty: 'transform',
                 transform: isHeaderVisible ? 'none' : 'rotate(90deg)'
               }}
             >
-              <IconBars width="1em" height="1em" />
+              <IconBars width="1.1em" height="1.1em" />
             </button>
+
+            <button
+              type="button"
+              title={isChatSmooth ? 'Smooth scroll' : 'Instant scroll'}
+              onClick={() => setIsChatSmooth((now) => !now)}
+              className="px-2 py-2"
+              style={{
+                transform: isChatSmooth ? 'scaleX(-1)' : 'none'
+              }}
+            >
+              <IconTachometerAlt width="1.2em" height="1.2em" />
+            </button>
+
             <button
               type="button"
               title="Filter text"
               onClick={() => setIsFilterVisible((now) => !now)}
-              className="px-4 py-2"
+              className="px-2 py-2"
             >
               <IconFilter width="1em" height="1em" />
             </button>
+
             <button
               type="button"
               title={isChatVisible ? 'Collapse chat' : 'Expand chat'}
               onClick={() => setIsChatVisible((now) => !now)}
-              className="text-lg px-4 py-2"
+              className="text-lg px-3 py-2"
             >
               <IconChevronDown
                 width="1em"

--- a/modules/shared/PageBase.tsx
+++ b/modules/shared/PageBase.tsx
@@ -4,6 +4,7 @@ import Head from 'next/head';
 import Header from './Header';
 import { apiStatusMessage } from '../../pages/api/v1/status';
 import MemoLinkify from './MemoLinkify';
+import useLocalStorageState from 'use-local-storage-state';
 
 export type PageBaseProps = {
   children?: React.ReactNode;
@@ -13,6 +14,7 @@ export type PageBaseProps = {
 const PageBase = (props: PageBaseProps) => {
   const [bannerHide, setBannerHide] = React.useState(true);
   const [bannerMessage, setBannerMessage] = React.useState('');
+  const [isHeaderVisible, setIsHeaderVisible] = useLocalStorageState('header:visible', { defaultValue: true });
 
   const fetchStatusMessage = async () => {
     const { timestamp, message, showBanner } = await apiStatusMessage();
@@ -61,10 +63,13 @@ const PageBase = (props: PageBaseProps) => {
           </a>
         </span>
       </div>
-      <Header />
+      {isHeaderVisible && (
+        <Header />
+      )}
       <div
         className={[
-          'container mx-auto mt-4 flex-1',
+          'container mx-auto flex-1',
+          isHeaderVisible ? 'mt-4' : '',
           props.flex ? 'flex flex-col' : '',
         ].join(' ')}
       >

--- a/modules/shared/PageBase.tsx
+++ b/modules/shared/PageBase.tsx
@@ -68,7 +68,7 @@ const PageBase = (props: PageBaseProps) => {
       )}
       <div
         className={[
-          'container mx-auto flex-1',
+          'lg:container lg:mx-auto flex-1',
           isHeaderVisible ? 'mt-4' : '',
           props.flex ? 'flex flex-col' : '',
         ].join(' ')}

--- a/modules/shared/PageBase.tsx
+++ b/modules/shared/PageBase.tsx
@@ -75,28 +75,32 @@ const PageBase = (props: PageBaseProps) => {
       >
         {props.children}
       </div>
-      <div className="mt-6 text-gray-500 text-center">
-        Made with 🍝 by{' '}
-        <a
-          href="https://twitter.com/kitsune_cw"
-          className="hover:underline"
-          target="_blank"
-          rel="noreferrer noopener nofollow"
-        >
-          kitsune
-        </a>
-        .
-      </div>
-      <div className="mb-6 text-center">
-        <a
-          href="https://github.com/ragtag-archive/archive-browser"
-          className="text-gray-500 hover:underline"
-          target="_blank"
-          rel="noreferrer noopener nofollow"
-        >
-          Source code
-        </a>
-      </div>
+      {isHeaderVisible && (
+        <>
+          <div className="mt-6 text-gray-500 text-center">
+            Made with 🍝 by{' '}
+            <a
+              href="https://twitter.com/kitsune_cw"
+              className="hover:underline"
+              target="_blank"
+              rel="noreferrer noopener nofollow"
+            >
+              kitsune
+            </a>
+            .
+          </div>
+          <div className="mb-6 text-center">
+            <a
+              href="https://github.com/ragtag-archive/archive-browser"
+              className="text-gray-500 hover:underline"
+              target="_blank"
+              rel="noreferrer noopener nofollow"
+            >
+              Source code
+            </a>
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "react-query": "^3.39.3",
     "react-srv3": "^1.0.3",
     "sharp": "^0.32.1",
-    "timeago.js": "^4.0.2"
+    "timeago.js": "^4.0.2",
+    "use-local-storage-state": "^19.5.0"
   },
   "devDependencies": {
     "@tailwindcss/ui": "^0.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2074,6 +2074,11 @@ update-browserslist-db@^1.0.11:
     escalade "^3.1.1"
     picocolors "^1.0.0"
 
+use-local-storage-state@^19.5.0:
+  version "19.5.0"
+  resolved "https://registry.yarnpkg.com/use-local-storage-state/-/use-local-storage-state-19.5.0.tgz#25bf46dd45b491020c03db516b46a4ff93b3a923"
+  integrity sha512-sUJAyFvsmqMpBhdwaRr7GTKkkoxb6PWeNVvpBDrLuwQF1PpbJRKIbOYeLLeqJI7B3wdfFlLLCBbmOdopiSTBOw==
+
 util-deprecate@^1.0.1, util-deprecate@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"


### PR DESCRIPTION
_Not sure if anyone besides me needs this, so feel free to reject this PR._

I like to watch videos on a second vertically positioned monitor, so I wanted to make some UI adjustments to make the player behave similar to YouTube.

Commits should be self-explanatory, so here're some videos:
<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/25cffe3e-dac6-4d39-ae88-55d72b56c959
</details>
<details>
<summary>After</summary>

https://github.com/user-attachments/assets/6f070fb7-ef00-4096-81e0-8e1331a9b9c1
</details>

---
What's added:
1. New chat panel buttons to toggle header/footer visibility and scrolling behavior (smooth or instant)
2. All button states are now saved to localStorage using [astoilkov/use-local-storage-state](https://github.com/astoilkov/use-local-storage-state)
The default hook didn't work well for me so I decided to add this one instead.
3. Made page container occupy full space if width is less than 1024px
4. Fixed some inconsistencies in height calculation for the chat panel
5. Made chat panel's scrollbar appear only on mouse hover
6. Added titles and simple animations to chat panel buttons

My main focus was the Custom Player page, but I decided to edit the Watch page as well since it can also benefit from these changes, in my opinion.
Hopefully nothing is broken there since unfortunately I can't test it properly myself _(yep, still too lazy to setup an environment)_.

Happy to make any adjustments, if needed. No rush with the review 🙂